### PR TITLE
Update dark mode

### DIFF
--- a/src/fonts/fonts.md
+++ b/src/fonts/fonts.md
@@ -6,7 +6,6 @@ Open Font License
 
 https://fonts.google.com/specimen/Kiwi+Maru?subset=japanese&noto.script=Jpan
 
-
 ## Makinas 4 Flat
 
 [License](https://moji-waku.com/mj_work_license/)

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Kiwi+Maru&display=swap" rel="stylesheet">
+
+  <!-- GitHub cards -->
+  <script defer src="https://tarptaeya.github.io/repo-card/repo-card.js"></script>
 </head>
 <body>
   <main>
@@ -48,7 +51,7 @@
           <h1>aseprite-scripts</h1>
 
           <section>
-            <a class="gh-card" href="https://github.com/Tsukina-7mochi/aseprite-scripts"><img src="https://gh-card.dev/repos/Tsukina-7mochi/aseprite-scripts.svg"></a>
+            <div class="repo-card" data-repo="Tsukina-7mochi/aseprite-scripts"></div>
           </section>
 
           <section>
@@ -63,7 +66,7 @@
           <h1>aseprite-type-definition</h1>
 
           <section>
-            <a class="gh-card" href="https://github.com/Tsukina-7mochi/aseprite-type-definition"><img src="https://gh-card.dev/repos/Tsukina-7mochi/aseprite-type-definition.svg"></a>
+            <div class="repo-card" data-repo="Tsukina-7mochi/aseprite-type-definition"></div>
           </section>
 
           <section>
@@ -79,10 +82,10 @@
 
           <section>
             <ul>
-              <li><a class="gh-card" href="https://tsukina-7mochi.github.io/turing-complete-unofficial/">解説ページ</a></li>
+              <li><a href="https://tsukina-7mochi.github.io/turing-complete-unofficial/">解説ページ</a></li>
             </ul>
 
-            <a class="gh-card" href="https://github.com/Tsukina-7mochi/turing-complete-unofficial"><img src="https://gh-card.dev/repos/Tsukina-7mochi/turing-complete-unofficial.svg"></a>
+            <div class="repo-card" data-repo="Tsukina-7mochi/turing-complete-unofficial"></div>
           </section>
 
           <section>
@@ -96,7 +99,7 @@
           <h1>Glitch Shader</h1>
 
           <section>
-            <a class="gh-card" href="https://github.com/Tsukina-7mochi/glitch-shader"><img src="https://gh-card.dev/repos/Tsukina-7mochi/glitch-shader.svg"></a>
+            <div class="repo-card" data-repo="Tsukina-7mochi/glitch-shader"></div>
           </section>
 
           <section>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,7 @@
-globalThis.addEventListener('load', () => {
+globalThis.addEventListener('DOMContentLoaded', () => {
+  if (globalThis.matchMedia('(prefers-color-scheme: dark)').matches == true) {
+    document.querySelectorAll('div.repo-card').forEach((el) => {
+      (el as HTMLElement).dataset['theme'] = 'dark-theme';
+    });
+  }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 globalThis.addEventListener('DOMContentLoaded', () => {
-  if (globalThis.matchMedia('(prefers-color-scheme: dark)').matches == true) {
-    document.querySelectorAll('div.repo-card').forEach((el) => {
-      (el as HTMLElement).dataset['theme'] = 'dark-theme';
+  globalThis.matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (preference) => {
+      document.querySelectorAll('div.repo-card').forEach((el) => {
+        (el as HTMLElement).dataset['theme'] = preference ? 'dark-theme' : '';
+      });
     });
-  }
 });

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,1 +1,0 @@
-@import "./style/style.scss"

--- a/src/style/defs-color.scss
+++ b/src/style/defs-color.scss
@@ -7,46 +7,27 @@ $c-def-white: #FFFFFF;
 $c-def-black: #38393f;
 $c-def-gray: #aeb4b6;
 
-//// theme definition ////
+:root {
+  --c-bg: #{$c-def-white};
+  --c-bg-hover: #{darken($c-def-white, 2%)};
+  --c-bg-active: #{darken($c-def-white, 4%)};
+  --c-main: #{$c-def-black};
+  --c-link: #{$c-def-highlight};
+  --c-link-visited: #{$c-def-highlight3};
+  --c-border: #{$c-def-gray};
+  --c-shadow: #{rgba($c-def-black, 40%)};
 
-// light
-$c-l-bg: $c-def-white;
-$c-l-bg-hover: darken($c-def-white, 2%);
-$c-l-bg-active: darken($c-def-white, 4%);
-$c-l-main: $c-def-black;
-$c-l-link: $c-def-highlight;
-$c-l-link-visited: $c-def-highlight3;
-$c-l-border: $c-def-gray;
-
-// dark
-$c-d-bg: $c-def-black;
-$c-d-bg-hover: lighten($c-def-black, 2%);
-$c-d-bg-active: lighten($c-def-black, 4%);
-$c-d-main: darken($c-def-white, 4%);
-$c-d-link: $c-def-highlight;
-$c-d-link-visited: $c-def-highlight3;
-$c-d-border: $c-def-gray;
-
-body {
-  --c-bg: $c-l-bg;
-  --c-bg-hover: $c-l-bg-hover;
-  --c-bg-active: $c-l-bg-active;
-  --c-main: $c-l-main;
-  --c-link: $c-l-link;
-  --c-link-visited: $c-l-link-visited;
-  --c-border: $c-l-border;
-}
-body.dark {
-  --c-bg: $c-d-bg;
-  --c-bg-hover: $c-d-bg-hover;
-  --c-bg-active: $c-d-bg-active;
-  --c-main: $c-d-main;
-  --c-link: $c-d-link;
-  --c-link-visited: $c-d-link-visited;
-  --c-border: $c-d-border;
+  @media (prefers-color-scheme: dark) {
+    --c-bg: #{$c-def-black};
+    --c-bg-hover: #{lighten($c-def-black, 2%)};
+    --c-bg-active: #{lighten($c-def-black, 4%)};
+    --c-main: #{darken($c-def-white, 4%)};
+    --c-link: #{$c-def-highlight};
+    --c-link-visited: #{$c-def-highlight3};
+    --c-border: #{$c-def-gray};
+    --c-shadow: #{rgba($c-def-white, 40%)};
+  }
 }
 
-//// other definition ////
 $radius: 1em;
 $gradient-basic: linear-gradient(to right, $c-def-highlight, $c-def-highlight2);
-$shadow-normal: 0px 0px 5px rgba($c-def-black, 40%);

--- a/src/style/defs-color.scss
+++ b/src/style/defs-color.scss
@@ -4,7 +4,7 @@ $c-def-highlight: #53cbcf;
 $c-def-highlight2: #267ed1;
 $c-def-highlight3: #e7961b;
 $c-def-white: #FFFFFF;
-$c-def-black: #38393f;
+$c-def-black: #0D1117;
 $c-def-gray: #aeb4b6;
 
 :root {

--- a/src/style/defs.scss
+++ b/src/style/defs.scss
@@ -15,7 +15,13 @@
 
 @mixin normalBoxRounded {
   border-radius: $radius;
-  box-shadow: $shadow-normal;
+  box-shadow: 0px 0px 5px var(--c-shadow);
   padding: 1em;
+
+  @media (prefers-color-scheme: dark) {
+    box-shadow: unset;
+    border: 2px solid var(--c-border);
+  }
+
   @content;
 }


### PR DESCRIPTION
- Add `@media (prefers-color-scheme: dark)` to stylesheet to change colors based on the color theme
- Replaced GitHub repository card with one that supports dark mode
  - Also changed page's background color so that it matches to color of card
  - Attached event listener to change of color scheme to switch color mode of repo card